### PR TITLE
Fix attachment not cached before editor opens

### DIFF
--- a/src/widgets/article-option/App.tsx
+++ b/src/widgets/article-option/App.tsx
@@ -25,8 +25,9 @@ export default function App() {
         })
     }, []);
 
-    const onSelectAttachment = (attachment: ArticleAttachment | null) => {
-        cacheAttachment(attachment)
+    const onSelectAttachment = async (attachment: ArticleAttachment | null) => {
+        // Ensure attachment is cached before opening the editor.
+        await cacheAttachment(attachment)
         window.open(`/app/diagramm-editor/editor`, '_blank')
         window.parent.location.href = `/articles/${YTApp.entity.id}`
     }
@@ -42,14 +43,14 @@ export default function App() {
         }
     }
 
-    function cacheAttachment(attachment: ArticleAttachment | null) {
+    async function cacheAttachment(attachment: ArticleAttachment | null) {
         const body = {
             id: YTApp.entity.id,
             attachmentId: attachment?.id ?? 'new',
             edited: Math.floor(Date.now() / 1000),
             forArticle: true
         }
-        void host.fetchApp("backend/cacheAttachment", {
+        await host.fetchApp("backend/cacheAttachment", {
             method: "POST",
             body: body
         })

--- a/src/widgets/issue-option/App.tsx
+++ b/src/widgets/issue-option/App.tsx
@@ -23,8 +23,9 @@ export default function App() {
         })
     }, []);
 
-    const onSelectAttachment = (attachment: IssueAttachment | null) => {
-        cacheAttachment(attachment)
+    const onSelectAttachment = async (attachment: IssueAttachment | null) => {
+        // Ensure attachment is cached before opening the editor.
+        await cacheAttachment(attachment)
         window.open(`/app/diagramm-editor/editor`, '_blank')
         window.parent.location.href = `/issue/${YTApp.entity.id}`
     }
@@ -40,14 +41,14 @@ export default function App() {
         }
     }
 
-    function cacheAttachment(attachment: IssueAttachment | null) {
+    async function cacheAttachment(attachment: IssueAttachment | null) {
         const body = {
             id: YTApp.entity.id,
             attachmentId: attachment?.id ?? 'new',
             edited: Math.floor(Date.now() / 1000),
             forArticle: false
         }
-        void host.fetchApp("backend/cacheAttachment", {
+        await host.fetchApp("backend/cacheAttachment", {
             method: "POST",
             body: body
         })


### PR DESCRIPTION
Wait until attachment is cached when editing or creating an attachment from an issue or an article. This prevents the race when the editor opens and the attachment hasn't yet been cached.

Fixes #4.